### PR TITLE
perf: resolve all 7 open performance issues

### DIFF
--- a/components/nodes/BaseNode.tsx
+++ b/components/nodes/BaseNode.tsx
@@ -99,7 +99,7 @@ export function BaseNode({ id, data, selected, icon, stats, hideLiveMetrics }: B
       data-testid={`node-${data.componentType}`}
       className={`
         relative group w-52 border border-edge bg-surface
-        transition-all duration-200
+        transition-[border-color,opacity] duration-200
         ${selected ? 'border-edge-strong' : ''}
         ${status === 'failed' ? 'opacity-60' : ''}
       `}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,11 +1,14 @@
+import { cache } from 'react'
 import { createClient } from '@supabase/supabase-js'
 
 // Server-side admin client — uses service role key, bypasses RLS.
 // Only call from Server Actions or Route Handlers after verifying Clerk session.
-export function createAdminClient() {
-  return createClient(
+// Wrapped with React cache() so all server actions within the same request
+// share one client instance instead of constructing a new one per call.
+export const createAdminClient = cache(() =>
+  createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { auth: { persistSession: false } },
   )
-}
+)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves all 7 open GitHub performance issues. Two were already fixed in the current codebase (#12, #13) and closed without code changes; the remaining five are addressed here.

- **#14** `completions.ts` — Replace racy SELECT + UPDATE XP pattern with the pre-existing atomic `increment_xp` RPC. Eliminates the race condition where two concurrent completions could overwrite each other's XP, and cuts 2 sequential DB round-trips to 1.
- **#15 + #10** `ChallengeLayout` — Extract draft-saving into a new render-less `DraftSaver` component that subscribes to the architecture store via Zustand's `subscribe()` API (outside React's render cycle). `ChallengeLayout` no longer subscribes to `nodes`/`edges`, so it no longer re-renders on every drag pixel.
- **#17** `lib/supabase/server.ts` — Wrap `createAdminClient` with React `cache()` so all server actions within the same request share one client instance.
- **#11** `BaseNode.tsx` — Replace `transition-all` with `transition-[border-color,opacity]` to avoid triggering style recalc for unrelated CSS properties on every state change.

## Test plan

- [x] Added `DraftSaver.test.tsx` — covers subscribe-on-mount, 1500ms trailing debounce, rapid-change debounce reset, and unmount cleanup
- [x] Updated `completions.test.ts` — replaced `mockUpdateEq`/`mockProfileSingle` with `mockRpc`; added assertions that `increment_xp` is called with correct args and is NOT called on a repeat pass
- [x] Fixed pre-existing e2e failure in `config-panel.spec.ts` — scoped `config-instanceCount` locators to the desktop sidebar wrapper to avoid strict-mode ambiguity with `MobileConfigPanel`
- [x] 165/165 unit tests passing
- [x] 40/40 e2e tests passing (10 skipped — require live Clerk credentials)

https://claude.ai/code/session_017P7S4SuivspHeeXfok7WzX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017P7S4SuivspHeeXfok7WzX)_