### PR TITLE
test: expand unit test coverage for sim and xp modules

### DIFF
--- a/tests/unit/lib/xp.test.ts
+++ b/tests/unit/lib/xp.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { xpForCompletion, computeLevel } from '@/lib/xp'
+
+// ── xpForCompletion ───────────────────────────────────────────────────────────
+
+describe('xpForCompletion', () => {
+  it('awards tier base + 0 bonus for score below 50', () => {
+    expect(xpForCompletion(1, 40)).toBe(75)
+  })
+
+  it('awards tier base + 5 bonus for score in [50, 74]', () => {
+    expect(xpForCompletion(1, 50)).toBe(80)
+    expect(xpForCompletion(1, 74)).toBe(80)
+  })
+
+  it('awards tier base + 15 bonus for score in [75, 89]', () => {
+    expect(xpForCompletion(1, 75)).toBe(90)
+    expect(xpForCompletion(1, 89)).toBe(90)
+  })
+
+  it('awards tier base + 30 bonus for score >= 90', () => {
+    expect(xpForCompletion(1, 90)).toBe(105)
+    expect(xpForCompletion(1, 100)).toBe(105)
+  })
+
+  it('uses 50 XP base for unknown tiers', () => {
+    expect(xpForCompletion(99, 0)).toBe(50)
+  })
+
+  it('uses correct base for each tier', () => {
+    expect(xpForCompletion(0, 0)).toBe(25)
+    expect(xpForCompletion(2, 0)).toBe(150)
+    expect(xpForCompletion(3, 0)).toBe(250)
+    expect(xpForCompletion(4, 0)).toBe(400)
+    expect(xpForCompletion(5, 0)).toBe(600)
+  })
+})
+
+// ── computeLevel ──────────────────────────────────────────────────────────────
+
+describe('computeLevel', () => {
+  it('returns Level 1 at 0 XP', () => {
+    const r = computeLevel(0)
+    expect(r.level).toBe(1)
+    expect(r.title).toBe('Junior Engineer')
+    expect(r.currentXp).toBe(0)
+    expect(r.nextLevelXp).toBe(100)
+    expect(r.progress).toBe(0)
+  })
+
+  it('returns Level 2 at exactly 100 XP', () => {
+    const r = computeLevel(100)
+    expect(r.level).toBe(2)
+    expect(r.title).toBe('Software Engineer')
+    expect(r.nextLevelXp).toBe(300)
+    expect(r.progress).toBe(0)
+  })
+
+  it('computes fractional progress within a level band', () => {
+    // Level 2: 100–300 XP. At 200 XP → 50% through.
+    const r = computeLevel(200)
+    expect(r.level).toBe(2)
+    expect(r.progress).toBeCloseTo(0.5, 5)
+  })
+
+  it('returns Level 3 at 300 XP', () => {
+    expect(computeLevel(300).level).toBe(3)
+    expect(computeLevel(300).title).toBe('Senior Engineer')
+  })
+
+  it('returns Level 4 at 700 XP', () => {
+    expect(computeLevel(700).level).toBe(4)
+  })
+
+  it('returns Level 5 at 1400 XP', () => {
+    expect(computeLevel(1400).level).toBe(5)
+  })
+
+  it('returns max level (6) at 2500 XP with null nextLevelXp', () => {
+    const r = computeLevel(2500)
+    expect(r.level).toBe(6)
+    expect(r.title).toBe('Distinguished Engineer')
+    expect(r.nextLevelXp).toBeNull()
+    expect(r.progress).toBe(0)
+  })
+
+  it('clamps progress to 1 at max level even with excess XP', () => {
+    expect(computeLevel(99999).progress).toBe(1)
+    expect(computeLevel(99999).nextLevelXp).toBeNull()
+  })
+})

--- a/tests/unit/sim/chaos.test.ts
+++ b/tests/unit/sim/chaos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildChaosMap } from '@/sim/chaos'
+import { buildChaosMap, activeEvents, eventForNode, makeChaosEvent } from '@/sim/chaos'
 import type { ChaosEvent } from '@/sim/types'
 
 function event(
@@ -71,5 +71,80 @@ describe('buildChaosMap', () => {
     const result = buildChaosMap([first, second], 500)
 
     expect(result['node-1']).toBe(first)
+  })
+})
+
+// ── activeEvents ──────────────────────────────────────────────────────────────
+
+describe('activeEvents', () => {
+  it('returns empty array when events list is empty', () => {
+    expect(activeEvents([], 500)).toEqual([])
+  })
+
+  it('returns only events active at simTimeMs', () => {
+    const e1 = event('e1', 'n1', 'latency-spike', 0,    1000)
+    const e2 = event('e2', 'n2', 'latency-spike', 2000, 1000)
+    expect(activeEvents([e1, e2], 500)).toEqual([e1])
+    expect(activeEvents([e1, e2], 2500)).toEqual([e2])
+  })
+
+  it('includes event starting exactly at simTimeMs', () => {
+    const e = event('e1', 'n1', 'latency-spike', 1000, 500)
+    expect(activeEvents([e], 1000)).toEqual([e])
+  })
+
+  it('excludes event whose end equals simTimeMs (half-open interval)', () => {
+    const e = event('e1', 'n1', 'latency-spike', 0, 1000)
+    expect(activeEvents([e], 1000)).toEqual([])
+  })
+})
+
+// ── eventForNode ─────────────────────────────────────────────────────────────
+
+describe('eventForNode', () => {
+  it('returns undefined when no events are active', () => {
+    const e = event('e1', 'n1', 'latency-spike', 0, 1000)
+    expect(eventForNode([e], 'n1', 2000)).toBeUndefined()
+  })
+
+  it('returns undefined when active events do not target the node', () => {
+    const e = event('e1', 'n2', 'latency-spike', 0, 1000)
+    expect(eventForNode([e], 'n1', 500)).toBeUndefined()
+  })
+
+  it('returns the single active event for the node', () => {
+    const e = event('e1', 'n1', 'latency-spike', 0, 1000)
+    expect(eventForNode([e], 'n1', 500)).toBe(e)
+  })
+
+  it('prefers node-failure over other active events for the same node', () => {
+    const spike   = event('e1', 'n1', 'latency-spike', 0, 1000)
+    const failure = event('e2', 'n1', 'node-failure',  0, 1000)
+    expect(eventForNode([spike, failure], 'n1', 500)).toBe(failure)
+    // also when failure is listed first
+    expect(eventForNode([failure, spike], 'n1', 500)).toBe(failure)
+  })
+
+  it('returns first non-failure event when no node-failure is present', () => {
+    const spike = event('e1', 'n1', 'latency-spike', 0, 1000)
+    const err   = event('e2', 'n1', 'error-rate',    0, 1000)
+    expect(eventForNode([spike, err], 'n1', 500)).toBe(spike)
+  })
+})
+
+// ── makeChaosEvent ────────────────────────────────────────────────────────────
+
+describe('makeChaosEvent', () => {
+  it('builds a ChaosEvent with the expected shape', () => {
+    const e = makeChaosEvent('n1', 'node-failure', 5000, 2000)
+    expect(e).toMatchObject({ nodeId: 'n1', type: 'node-failure', startSimMs: 5000, durationMs: 2000, magnitude: 5 })
+  })
+
+  it('generates a deterministic id from nodeId, type, and startSimMs', () => {
+    expect(makeChaosEvent('n1', 'latency-spike', 1000, 500).id).toBe('n1-latency-spike-1000')
+  })
+
+  it('accepts a custom magnitude', () => {
+    expect(makeChaosEvent('n1', 'node-failure', 0, 1000, 10).magnitude).toBe(10)
   })
 })

--- a/tests/unit/sim/components.test.ts
+++ b/tests/unit/sim/components.test.ts
@@ -388,3 +388,36 @@ describe('computeClient', () => {
     expect(snap.status).toBe('idle')
   })
 })
+
+// ── computeNode — default / unknown type ──────────────────────────────────────
+
+describe('computeNode — unknown component type', () => {
+  it('returns an idle snapshot for unrecognised component types', () => {
+    const unknown = node('u1', 'client', {}) // use valid SimNode but cast type
+    const patched = { ...unknown, componentType: 'unknown-future-type' } as unknown as SimNode
+    const snap = computeNode(patched, 100, STATE)
+    expect(snap.id).toBe('u1')
+    expect(snap.outputRps).toBe(0)
+    expect(snap.status).toBe('idle')
+  })
+})
+
+// ── computeNode — overloaded database (rho > 1) ───────────────────────────────
+
+describe('computeNode — overloaded database', () => {
+  const dbNode = node<DatabaseConfig>('db1', 'database', {
+    instanceType: 'db.t3.medium',
+    maxConnections: 10,   // maxRps = 10 * 5 * 1 = 50
+    readReplicas: 0,
+    multiAz: false,
+  })
+
+  it('caps outputRps at maxRps * 0.999 and has errorRate > 0 when overloaded', () => {
+    const snap = computeNode(dbNode, 200, STATE)  // rho = 200/50 = 4 → overloaded
+    expect(snap.errorRate).toBeGreaterThan(0)
+    expect(snap.outputRps).toBeLessThan(200)
+    // outputRps = maxRps * 0.999 = 50 * 0.999 = 49.95
+    expect(snap.outputRps).toBeCloseTo(49.95, 1)
+    expect(snap.status).toBe('saturated')
+  })
+})

--- a/tests/unit/sim/graph.test.ts
+++ b/tests/unit/sim/graph.test.ts
@@ -193,3 +193,29 @@ describe('resolveGraph — system aggregates', () => {
     expect(snap.systemCostPerHour).toBeCloseTo(0.0416 * 2, 4)
   })
 })
+
+describe('resolveGraph — unrouted client nodes', () => {
+  it('blends dropped client traffic into systemErrorRate', () => {
+    // A client with no outgoing edges: all its output RPS is dropped.
+    const graph: SimGraph = {
+      nodes: [clientNode('cl1', 100)],
+      edges: [],
+    }
+    const clientRpsMap = { cl1: 100 }
+    const snap = resolveGraph(graph, emptyState(graph), 0, 0, clientRpsMap)
+    // All ingress is unrouted → systemErrorRate should be 1 (100%)
+    expect(snap.systemErrorRate).toBe(1)
+  })
+
+  it('partial unrouted traffic blends proportionally into systemErrorRate', () => {
+    // cl1 → srv (routed), cl2 has no edges (unrouted)
+    const graph: SimGraph = {
+      nodes: [clientNode('cl1', 100), clientNode('cl2', 100), serverNode('srv')],
+      edges: [edge('e1', 'cl1', 'srv')],
+    }
+    const clientRpsMap = { cl1: 100, cl2: 100 }
+    const snap = resolveGraph(graph, emptyState(graph), 0, 0, clientRpsMap)
+    // 100 / 200 ingress is unrouted → systemErrorRate ≥ 0.5
+    expect(snap.systemErrorRate).toBeGreaterThanOrEqual(0.5)
+  })
+})

--- a/tests/unit/sim/traffic.test.ts
+++ b/tests/unit/sim/traffic.test.ts
@@ -130,3 +130,20 @@ describe('sampleClientPreset', () => {
     })
   })
 })
+
+// ── sampleTraffic (TrafficConfig wrapper) ─────────────────────────────────────
+
+import { sampleTraffic } from '@/sim/traffic'
+import type { TrafficConfig } from '@/sim/types'
+
+describe('sampleTraffic', () => {
+  it('delegates to sampleWaypoints and interpolates correctly', () => {
+    const config: TrafficConfig = {
+      durationMs: 60_000,
+      waypoints: [{ timeMs: 0, rps: 100 }, { timeMs: 60_000, rps: 200 }],
+    }
+    expect(sampleTraffic(config, 30_000)).toBeCloseTo(150, 5)
+    expect(sampleTraffic(config, 0)).toBe(100)
+    expect(sampleTraffic(config, 60_000)).toBe(200)
+  })
+})


### PR DESCRIPTION
Add tests for previously-uncovered functions in chaos (activeEvents,
eventForNode, makeChaosEvent), sim components (unknown type, overloaded
database), graph (unrouted client node), traffic (sampleTraffic), and
xp (all tier bases, all level bands with progress clamping).

https://claude.ai/code/session_017P7S4SuivspHeeXfok7WzX